### PR TITLE
Update GetVersionString doxygen returns

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the numconvert distribution (https://github.com/baskapteijn/numconvert).
- * Copyright (c) 2018 Bas Kapteijn.
+ * Copyright (c) 2019 Bas Kapteijn.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/version.h
+++ b/src/version.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the numconvert distribution (https://github.com/baskapteijn/numconvert).
- * Copyright (c) 2018 Bas Kapteijn.
+ * Copyright (c) 2019 Bas Kapteijn.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,9 +22,9 @@
 
 #define VERSION_MAJOR       1u
 #define VERSION_MINOR       0u
-#define VERSION_PATCH       4u
+#define VERSION_PATCH       5u
 
-#define VERSION_STRING_LEN  12 /* mjr.mnr.pat + \0 */
+#define VERSION_STRING_LEN  12u /* mjr.mnr.pat + \0 */
 
 /*!
  * \brief Return the current version.
@@ -32,7 +32,7 @@
  *      Semantic versioning 2.0.0 as per <https://semver.org/>.
  *      Each part of the version number (major, minor, patch) shall be limited to a value no more
  *      than 255.
- * \returns
+ * \returns A char pointer to the version string.
  */
 static inline const char* GetVersionString(void)
 {

--- a/test/functional/stdout/12.txt
+++ b/test/functional/stdout/12.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/13.txt
+++ b/test/functional/stdout/13.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/26.txt
+++ b/test/functional/stdout/26.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/27.txt
+++ b/test/functional/stdout/27.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/28.txt
+++ b/test/functional/stdout/28.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/29.txt
+++ b/test/functional/stdout/29.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/3.txt
+++ b/test/functional/stdout/3.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/30.txt
+++ b/test/functional/stdout/30.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/31.txt
+++ b/test/functional/stdout/31.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/32.txt
+++ b/test/functional/stdout/32.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/33.txt
+++ b/test/functional/stdout/33.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/34.txt
+++ b/test/functional/stdout/34.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/35.txt
+++ b/test/functional/stdout/35.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/36.txt
+++ b/test/functional/stdout/36.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/37.txt
+++ b/test/functional/stdout/37.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/4.txt
+++ b/test/functional/stdout/4.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]

--- a/test/functional/stdout/7.txt
+++ b/test/functional/stdout/7.txt
@@ -1,4 +1,4 @@
-Version 1.0.4
+Version 1.0.5
 
 Usage:
   numconvert [prefix]<value>[postfix]


### PR DESCRIPTION
Update copyright headers to 2019.
Bump version to 1.0.5.
Bump functional tests to match 1.0.5.

This fixes #54 